### PR TITLE
Fix log level menu issue

### DIFF
--- a/MenuUtil.hpp
+++ b/MenuUtil.hpp
@@ -169,7 +169,7 @@ namespace MenuUtil
 
 		void UpdateLogLevelMenu() noexcept
 		{
-			CheckMenuRadioItem(g_hLogLevelMenu, 0, 4, static_cast<UINT>(g_clashConfig.logLevel), MF_BYPOSITION);
+			CheckMenuRadioItem(g_hLogLevelMenu, 0, 4, static_cast<UINT>(g_clashConfig.logLevel) - 1, MF_BYPOSITION);
 		}
 
 		void UpdatePortsMenu()


### PR DESCRIPTION
此处应当将从clash获取的loglevel值 - 1才能正确显示当前选择的loglevel等级。