### PR TITLE
Fix GitHub Actions not triggered by push

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,7 +2,7 @@ name: Push Build
 
 on:
   push:
-    tags-ignore:
+    branches:
       - '**'
 
 jobs:


### PR DESCRIPTION
参考：[https://github.community/t/dont-run-on-tag-creation/137469/4](https://github.community/t/dont-run-on-tag-creation/137469/4) 与 [https://github.community/t/dont-run-on-tag-creation/137469/7](https://github.community/t/dont-run-on-tag-creation/137469/7)

> If you define only tags or only branches, the workflow won’t run for events affecting the undefined Git ref.

使用 `tags-ignore: - "**"` 将使得 tags 和 commits 同时被忽略，因此 push build 在任何情况下都不会被运行